### PR TITLE
Fixed the following:

### DIFF
--- a/common/help.sh
+++ b/common/help.sh
@@ -21,5 +21,5 @@ function print_header() {
 
 function print_help() {
     print_line "this is all the help you get."
-    print_line "https://github.com/malscent/marketplace-scripts/blob/main/readme.md"
+    print_line "https://github.com/couchbase-partners/marketplace-scripts/blob/main/readme.md"
 }

--- a/common/loggers.sh
+++ b/common/loggers.sh
@@ -12,23 +12,35 @@ __LOG_COLOR_GREY='\033[1;30m'
 __LOG_TIMESTAMP_FORMAT="%m-%d-%YT%R:%S"
 
 function __log_error() {
+    local USED_COLOR=$__LOG_COLOR_RED
+    if [[ "${NO_COLOR}" == "1" ]]; then
+        USED_COLOR=$__LOG_NO_COLOR
+    fi
     NOW_ERROR=$(date +${__LOG_TIMESTAMP_FORMAT})
     if [[ "${ERROR}" == "1" ]]; then
-        echo -e "${__LOG_COLOR_RED}[${NOW_ERROR}][ERROR]: $*${__LOG_NO_COLOR}"
+        echo -e "${USED_COLOR}[${NOW_ERROR}][ERROR]: $*${__LOG_NO_COLOR}"
     fi
 }
 
 function __log_debug() {
+    local USED_COLOR=$__LOG_COLOR_GREY
+    if [[ "${NO_COLOR}" == "1" ]]; then
+        USED_COLOR=$__LOG_NO_COLOR
+    fi
     NOW_DEBUG=$(date +${__LOG_TIMESTAMP_FORMAT})
     if [[ "${DEBUG}" == "1" ]]; then
-        echo -e "${__LOG_COLOR_GREY}[${NOW_DEBUG}][DEBUG]: $*${__LOG_NO_COLOR}"
+        echo -e "${USED_COLOR}[${NOW_DEBUG}][DEBUG]: $*${__LOG_NO_COLOR}"
     fi
 }
 
 function __log_warning() {
+    local USED_COLOR=$__LOG_COLOR_YELLOW
+    if [[ "${NO_COLOR}" == "1" ]]; then
+        USED_COLOR=$__LOG_NO_COLOR
+    fi
     NOW_WARNING=$(date +${__LOG_TIMESTAMP_FORMAT})
     if [[ "${WARNING}" == "1" ]]; then
-        echo -e "${__LOG_COLOR_YELLOW}[${NOW_WARNING}][WARN]: $*${__LOG_NO_COLOR}"
+        echo -e "${USED_COLOR}[${NOW_WARNING}][WARN]: $*${__LOG_NO_COLOR}"
     fi
 }
 

--- a/installers/centos_installer.sh
+++ b/installers/centos_installer.sh
@@ -2,8 +2,8 @@
 
 setSwappiness ()
 {
-    KERNAL_VERSION=$(uname -r)
-    RET=$(__compareVersions "$KERNAL_VERSION" "3.5.0")
+    KERNEL_VERSION=$(uname -r)
+    RET=$(__compareVersions "$KERNEL_VERSION" "3.5.0")
     SWAPPINESS=0
     if [[ "$RET" == "1" ]]; then
         SWAPPINESS=1
@@ -16,6 +16,7 @@ setSwappiness ()
     __log_debug "Swappiness set to Zero"
 }
 
+# https://docs.couchbase.com/server/current/install/thp-disable.html
 turnOffTransparentHugepages ()
 {
     __log_debug "Disabling Transparent Hugepages"
@@ -84,11 +85,7 @@ function __install_prerequisites() {
     fi
     __log_debug "Prequisites Installation"
     yum update -q -y
-    yum install jq -q -y
-    yum install epel-release -q -y
-    yum install python2 -q -y
-    yum install net-tools -q -y
-    yum install wget -q -y
+    yum install epel-release jq net-tools python2 wget -q -y
     python2 -m pip -q install httplib2
 }
 

--- a/installers/redhat_installer.sh
+++ b/installers/redhat_installer.sh
@@ -2,8 +2,8 @@
 
 setSwappiness ()
 {
-    KERNAL_VERSION=$(uname -r)
-    RET=$(__compareVersions "$KERNAL_VERSION" "3.5.0")
+    KERNEL_VERSION=$(uname -r)
+    RET=$(__compareVersions "$KERNEL_VERSION" "3.5.0")
     SWAPPINESS=0
     if [[ "$RET" == "1" ]]; then
         SWAPPINESS=1
@@ -16,6 +16,7 @@ setSwappiness ()
     __log_debug "Swappiness set to Zero"
 }
 
+#https://docs.couchbase.com/server/current/install/thp-disable.html
 turnOffTransparentHugepages ()
 {
     __log_debug "Disabling Transparent Hugepages"
@@ -88,12 +89,7 @@ function __install_prerequisites() {
     fi
     __log_debug "Prequisites Installation"
     yum update -q -y
-    yum install jq -q -y
-    yum install python2 -q -y
-    yum install net-tools -q -y
-    yum install wget -q -y
-    yum install hostname -q -y
-    yum install bind-utils -y -q
+    yum install bind-utils hostname net-tools python2 wgetjq -q -y
     python2 -m pip -q install httplib2
 }
 

--- a/installers/ubuntu_installer.sh
+++ b/installers/ubuntu_installer.sh
@@ -49,6 +49,7 @@ formatDataDisk ()
     chgrp couchbase $MOUNTPOINT
 }
 
+# https://docs.couchbase.com/server/current/install/thp-disable.html
 turnOffTransparentHugepages ()
 {
     __log_debug "Disabling Transparent Hugepages"
@@ -121,23 +122,6 @@ OS_VERSION=$(awk 'NR==1{print $2}' /etc/issue | cut -c-5)
 # Prerequisite installation
 # This is called by the main.sh to set up all necessary libaries
 function __install_prerequisites() {
-    # Here we are unlocking dpkg should it be locked by another process
-    # FILE="/var/lib/dpkg/lock-frontend"
-    # DB="/var/lib/dpkg/lock"
-    # if [[ -f "$FILE" ]]; then
-    # PID=$(lsof -t $FILE)
-    # echo "lock-frontend locked by $PID"
-    # echo "Killing $PID"
-    # kill -9 "${PID##p}"
-    # echo "$PID Killed"
-    # rm $FILE
-    # PID=$(lsof -t $DB)
-    # echo "DB locked by $PID"
-    # kill -9 "${PID##p}"
-    # rm $DB
-    # dpkg --configure -a
-    # fi
-
     __log_debug "Checking OS compatability"
     __log_debug "OS version is: ${OS_VERSION}"
     __log_debug "Supported Versions are: ${UBUNTU_OS_SUPPORTED_VERSIONS[*]}"
@@ -148,27 +132,19 @@ function __install_prerequisites() {
     fi
     __log_info "Installing prerequisites..."
     
-    apt-get update > /dev/null
+    __log_debug "Updating package repositories"
+    until apt-get update > /dev/null; do
+        __log_error "Error performing package repository update"
+        sleep 2
+    done
     # shellcheck disable=SC2034
     DEBIAN_FRONTEND=noninteractive
-    __log_debug "Installing apt-utils"
-    apt-get install --assume-yes apt-utils dialog  -qq > /dev/null
-    __log_debug "apt-utils install complete"
-    __log_debug "Installing python-httplib2"
-    apt-get -y install python-httplib2 -qq > /dev/null
-    __log_debug "python-httplib2 install complete"
-    __log_debug "Installing jq"
-    apt-get -y install jq -qq > /dev/null
-    __log_debug "jq install complete"
-    __log_debug "Installing net-tools"
-    apt-get -y install net-tools -qq > /dev/null
-    __log_debug "net-tools install complete"
-    __log_debug "Installing wget"
-    apt-get -y install wget -qq > /dev/null
-    __log_debug "wget install complete."
-    __log_debug "Installing lsb_release"
-    apt-get -y install lsb-release -qq > /dev/null
-    __log_debug "lsb_release install complete."
+    __log_debug "Installing Prequisites"
+    until apt-get install --assume-yes apt-utils dialog python-httplib2 jq net-tools wget lsb-release  -qq > /dev/null; do
+        __log_error "Error during pre-requisite installation"
+        sleep 2
+    done
+    __log_debug "Prequisitie Installation complete"
 }
 
 # Main Installer function.  This actually performs the download of the binaries
@@ -192,13 +168,19 @@ function __install_couchbase() {
     __log_debug "Downloading installer to: ${tmp}"
     wget -O "${tmp}/couchbase-server-enterprise_${version}-ubuntu${OS_VERSION}_amd64.deb" "http://packages.couchbase.com/releases/${version}/couchbase-server-enterprise_${version}-ubuntu${OS_VERSION}_amd64.deb" -q
     __log_debug "Download Complete.  Beginning Unpacking"
-    if ! dpkg -i "${tmp}/couchbase-server-enterprise_${version}-ubuntu${OS_VERSION}_amd64.deb" > /dev/null; then
+    until dpkg -i "${tmp}/couchbase-server-enterprise_${version}-ubuntu${OS_VERSION}_amd64.deb" > /dev/null; do
         __log_error "Error while installing ${tmp}/couchbase-server-enterprise_${version}-ubuntu${OS_VERSION}_amd64.deb"
-        exit 1
-    fi
+        sleep 1
+    done
     __log_debug "Unpacking complete.  Beginning Installation"
-    apt-get update -qq > /dev/null
-    apt-get -y install couchbase-server -qq > /dev/null
+    until apt-get update -qq > /dev/null; do
+        __log_error "Error updating package repositories"
+        sleep 1
+    done
+    until apt-get -y install couchbase-server -qq > /dev/null; do
+        __log_error "Error while installing ${tmp}/couchbase-server-enterprise_${version}-ubuntu${OS_VERSION}_amd64.deb"
+        sleep 1
+    done
 
     #return the location of where the couchbase cli is installed
     export CLI_INSTALL_LOCATION="/opt/couchbase/bin"

--- a/readme.md
+++ b/readme.md
@@ -2,6 +2,17 @@
 
 These scripts are intended for usage to install and cluster multiple VM's, containers, etc.
 
+## Getting Started
+
+These scripts are bundled into a single output file with [bash_bunder](https://github.com/malscent/bash_bundler).  It can be installed with 
+```
+go get github.com/malscent/bash_bundler
+```
+
+Bundling:
+
+```bash_bundler bundle -e ./main.sh -o ./build/couchbase_installer.sh```
+
 ## Parameters
 
 ### ```-v|--version```
@@ -53,6 +64,12 @@ These scripts are intended for usage to install and cluster multiple VM's, conta
 
 **Purpose**: Specifies that the script should run forever to maintain container execution after script completes.  Used mainly for testing purposes.
 
+### ```-c|--no-color```
+
+**Usage**: ```./main.sh -c```
+
+**Purpose**: Specifies that the script should run in a no-color mode. This is for environments where colored output can be a net negative to execution.
+
 ### ```-e|--environment```
 
 **Usage**: ```./main.sh -e AZURE```
@@ -80,6 +97,8 @@ These scripts are intended for usage to install and cluster multiple VM's, conta
 ```
 
 ## Using Containers with arguments for testing
+
+Docker containers are intended for usage testing and are not representative of the expected use case. Docker Containers only use the latest image of the OS,  We do not try to test in older docker images.  If you want to use Couchbase Server inside a docker container, see the approved docker container images at [DockerHub](https://hub.docker.com/_/couchbase)
 
 ### Create Network
 First you need to create a network to join your nodes to.


### PR DESCRIPTION
Normalized Header to set -euo pipefail
Added option to remove color from output of logging
Spell Kernel Correctly
Added link to THP disable function to CB documentation
Revamped prereq installs into single line
Added loops to ubuntu and debian installers to handle locking issues on startup scripts
Updated Documentation
Removed set +/- e on CB CLI loops
Added notes to documentation about Docker Container Images